### PR TITLE
Update to Python3 and minor updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Use pip:
 
 ## Usage
 
-	Usage: check-measurement [OPTIONS] COMMAND1 [ARGS]...
-
+	Usage: check-measurement [OPTIONS1] COMMAND [OPTIONS2|OPTIONS3]...
+	
 	Command line entry point. Defines common arguments.
-
+	
 	Options 1:
 	  -v, --verbose               Can be specified multiple times for increasing verbosity
 	  --hostname TEXT             InfluxDB hostname
@@ -58,25 +58,55 @@ Use pip:
 								  considered a warning
 	  --timeout INTEGER           Timeout in seconds for connecting to InfluxDB
 	  --help                      Show this message and exit.
-
+	
 	Commands:
 	  query   Run an explicit query.
 	  single  Run a query for a single measurement.
-
-	check-measurement [OPTIONS1] single [OPTIONS2] MEASUREMENT HOSTNAME
-
+	
+	Usage1: check-measurement [OPTIONS1] single [OPTIONS2] MEASUREMENT HOSTNAME
+	
 	  Run a query for a single measurement.
-
+	
 	Options 2:
 	  --age TEXT
 	  --where TEXT  Extra where conditions to include.
 	  --field TEXT
 	  --help        Show this message and exit.
-
-
-	Usage: check-measurement [OPTIONS1] query [OPTIONS3] QUERY
-
+	
+	Usage2 : check-measurement [OPTIONS1] query [OPTIONS3] QUERY
+	
 	  Run an explicit query.
-
+	
 	Options 3:
 	  --help  Show this message and exit.
+
+## Examples
+
+### Run a query for a single measurement
+
+Run a query for a `cpu` measurement `cpu-total`  the field value `usage_iowait` filtered for host `yourhost`.The options used  before the `single` command and after the `single` command can not be switched.
+
+```shell
+$./check-measurement --mean-error-range 10 --mean-warning-range 5 single --field usage_iowait --where cpu='cpu-total' --age 2m cpu yourhost
+```
+
+Output:
+
+```shell
+MEASUREMENTS OK - cpu is [0.2507941815741449, 0.21819402484046085, 0.19283977530009686, 0.3185247275776435] | count=4;2:;1: mean=0.24508817732308652;5;10
+```
+
+### Run an explicit query
+
+Run an explicit query `SELECT time, usage_iowait FROM cpu WHERE time > now() - 2m AND host = 'mo4' AND cpu = 'cpu-total'` 
+
+```shell
+$./check-measurement --mean-error-range 10 --mean-warning-range 5 query "SELECT time, usage_iowait FROM cpu WHERE time > now() - 2m AND host = 'yourhost' AND cpu = 'cpu-total'"
+```
+
+Output:
+
+```shell
+MEASUREMENTS OK - cpu is [0.2507941815741449, 0.21819402484046085, 0.19283977530009686, 0.3185247275776435] | count=4;2:;1: mean=0.24508817732308652;5;10
+```
+

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ Use pip:
 	Command line entry point. Defines common arguments.
 
 	Options:
-	  -v, --verbose
+	  -v, --verbose               Can be specified multiple times for increasing verbosity
 	  --hostname TEXT             InfluxDB hostname
 	  --port INTEGER              InfluxDB port
 	  --username TEXT             InfluxDB usernanme
 	  --password TEXT             InfluxDB password
-	  --database TEXT             InfluxDB database name
+	  --database TEXT             InfluxDB database name, default 'telegraf'
 	  --count-error-range TEXT    Range of measurement counts that are NOT
 								  considered an error
 	  --count-warning-range TEXT  Range of measurement counts that are NOT

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Use pip:
 
 	Command line entry point. Defines common arguments.
 
-	Options:
+	Options 1:
 	  -v, --verbose               Can be specified multiple times for increasing verbosity
 	  --hostname TEXT             InfluxDB hostname
 	  --port INTEGER              InfluxDB port
@@ -63,20 +63,20 @@ Use pip:
 	  query   Run an explicit query.
 	  single  Run a query for a single measurement.
 
-	check-measurement [OPTIONS] single [OPTIONS] MEASUREMENT HOSTNAME
+	check-measurement [OPTIONS1] single [OPTIONS2] MEASUREMENT HOSTNAME
 
 	  Run a query for a single measurement.
 
-	Options:
+	Options 2:
 	  --age TEXT
 	  --where TEXT  Extra where conditions to include.
 	  --field TEXT
 	  --help        Show this message and exit.
 
 
-	Usage: check-measurement query [OPTIONS] QUERY
+	Usage: check-measurement [OPTIONS1] query [OPTIONS3] QUERY
 
 	  Run an explicit query.
 
-	Options:
+	Options 3:
 	  --help  Show this message and exit.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Use pip:
 								  considered a warning
 	  --mean-error-range TEXT     Range of measurement means that are NOT
 								  considered an error
-	  --mean-warning-range TEXT   Range of measurement counts that are NOT
+	  --mean-warning-range TEXT   Range of measurement means that are NOT
 								  considered a warning
 	  --timeout INTEGER           Timeout in seconds for connecting to InfluxDB
 	  --help                      Show this message and exit.

--- a/README.md
+++ b/README.md
@@ -83,30 +83,22 @@ Use pip:
 ## Examples
 
 ### Run a query for a single measurement
-
 Run a query for a `cpu` measurement `cpu-total`  the field value `usage_iowait` filtered for host `yourhost`.The options used  before the `single` command and after the `single` command can not be switched.
 
-```shell
-$./check-measurement --mean-error-range 10 --mean-warning-range 5 single --field usage_iowait --where cpu='cpu-total' --age 2m cpu yourhost
-```
+    $./check-measurement --mean-error-range 10 --mean-warning-range 5 single \
+    --field usage_iowait --where cpu='cpu-total' --age 2m cpu yourhost
 
 Output:
 
-```shell
-MEASUREMENTS OK - cpu is [0.2507941815741449, 0.21819402484046085, 0.19283977530009686, 0.3185247275776435] | count=4;2:;1: mean=0.24508817732308652;5;10
-```
+    MEASUREMENTS OK - cpu is [0.2507941815741449, 0.21819402484046085, 0.19283977530009686, 0.3185247275776435] | count=4;2:;1: mean=0.24508817732308652;5;10
 
 ### Run an explicit query
-
 Run an explicit query `SELECT time, usage_iowait FROM cpu WHERE time > now() - 2m AND host = 'mo4' AND cpu = 'cpu-total'` 
 
-```shell
-$./check-measurement --mean-error-range 10 --mean-warning-range 5 query "SELECT time, usage_iowait FROM cpu WHERE time > now() - 2m AND host = 'yourhost' AND cpu = 'cpu-total'"
-```
+    $./check-measurement --mean-error-range 10 --mean-warning-range 5 query \
+    "SELECT time, usage_iowait FROM cpu WHERE time > now() - 2m AND host = 'yourhost' AND cpu = 'cpu-total'"
 
 Output:
 
-```shell
-MEASUREMENTS OK - cpu is [0.2507941815741449, 0.21819402484046085, 0.19283977530009686, 0.3185247275776435] | count=4;2:;1: mean=0.24508817732308652;5;10
-```
+    MEASUREMENTS OK - cpu is [0.2507941815741449, 0.21819402484046085, 0.19283977530009686, 0.3185247275776435] | count=4;2:;1: mean=0.24508817732308652;5;10
 

--- a/influxdbnagiosplugin/main.py
+++ b/influxdbnagiosplugin/main.py
@@ -15,12 +15,12 @@ from influxdbnagiosplugin.summaries import MeasurementValuesSummary
 
 
 @group(chain=True)
-@option("-v", "--verbose", count=True)
+@option("-v", "--verbose", count=True, help="Can be specified multiple times for increasing verbosity")
 @option("--hostname", default="localhost", help="InfluxDB hostname")
 @option("--port", default=8086, help="InfluxDB port")
 @option("--username", default="influxdb", help="InfluxDB usernanme")
 @option("--password", default="secret", help="InfluxDB password")
-@option("--database", default="telegraf", help="InfluxDB database name")
+@option("--database", default="telegraf", help="InfluxDB database name, default \'telegraf\'")
 @option("--count-error-range", default="1:", help="Range of measurement counts that are NOT considered an error")  # noqa
 @option("--count-warning-range", default="2:", help="Range of measurement counts that are NOT considered a warning")  # noqa
 @option("--mean-error-range", default="", help="Range of measurement means that are NOT considered an error")  # noqa

--- a/influxdbnagiosplugin/main.py
+++ b/influxdbnagiosplugin/main.py
@@ -24,7 +24,7 @@ from influxdbnagiosplugin.summaries import MeasurementValuesSummary
 @option("--count-error-range", default="1:", help="Range of measurement counts that are NOT considered an error")  # noqa
 @option("--count-warning-range", default="2:", help="Range of measurement counts that are NOT considered a warning")  # noqa
 @option("--mean-error-range", default="", help="Range of measurement means that are NOT considered an error")  # noqa
-@option("--mean-warning-range", default="", help="Range of measurement counts that are NOT considered a warning")  # noqa
+@option("--mean-warning-range", default="", help="Range of measurement means that are NOT considered a warning")  # noqa
 @option("--timeout", default=5, help="Timeout in seconds for connecting to InfluxDB")
 def main(**kwargs):
     """

--- a/influxdbnagiosplugin/resources.py
+++ b/influxdbnagiosplugin/resources.py
@@ -43,7 +43,7 @@ class Measurements(Resource):
         Query InfluxDB; yield the count and mean of the measurements.
         """
         def get_value(result):
-            for key, value in result.iteritems():
+            for key, value in result.items():
                 if key != "time":
                     return value
 

--- a/influxdbnagiosplugin/summaries.py
+++ b/influxdbnagiosplugin/summaries.py
@@ -18,7 +18,7 @@ class MeasurementValuesSummary(Summary):
         self.query = query
 
     def ok(self, results):
-        result = filter(is_values, results)[0]
+        result = next(filter(is_values, results))
         return "{} is {}".format(
             self.query.measurements[0] if self.query.measurements else "result",
             result.metric.value,

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from setuptools import setup, find_packages
 
-__version__ = "1.4"
+__version__ = "1.5"
 
 setup(
     name="influxdbnagiosplugin",


### PR DESCRIPTION
Dear Vince,

I needed a nagios plugin to monitor some values in influx so I played around with 'influxdb-nagios-plugin'. I updated the code to Python3 and tested on Python3.5.2. I think it is OK. Tweaked the documentation and added two examples to the README.

However I could not get the tests running, Pytest throws an error, I do not why because hamcrest is installed in my env.

```
$ pytest
Test session starts (platform: linux, Python 3.5.2, pytest 5.0.0, pytest-sugar 0.9.2)
rootdir: /home/paulb/dev/influxdb-nagios-plugin-paulb/influxdb-nagios-plugin
plugins: mock-1.10.4, sugar-0.9.2, dash-1.0.0
collecting ...
――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― influxdbnagiosplugin/tests/test_query.py ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
ImportError while importing test module '/home/paulb/dev/influxdb-nagios-plugin-paulb/influxdb-nagios-plugin/influxdbnagiosplugin/tests/test_query.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
test_query.py:4: in <module>
    from hamcrest import assert_that, is_, equal_to
E   ImportError: No module named 'hamcrest'
```

Could you review my PR and do a suggestion how to fix `pytest`.

With kind regards,

Paul Boot.